### PR TITLE
Remove dependency on ppx_deriving

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,6 @@
 (library
  (public_name alg_structs)
- (preprocess (pps ppx_deriving
-                  ppx_deriving.eq
+ (preprocess (pps ppx_deriving.eq
                   ppx_deriving.ord)))
 
 (documentation


### PR DESCRIPTION
The ppx_deriving package doesn't actually contain a library named "ppx_deriving", but it does contain several libraries with "ppx_deriving" as a prefix (e.g. ppx_deriving.eq, ppx_deriving.ord). Currently it's possible to depend on library prefixes like "ppx_deriving" when the package containing the library is installed globally, but not if the package is vendored. That is, if the package ppx_deriving were vendored, dune would be unable to find a library named "ppx_deriving".